### PR TITLE
Helper Fixes

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -113,27 +113,27 @@ func (c *Conn) AnswerCall(ctx context.Context, uuid string) error {
 }
 
 // Phrase - Executes the mod_dptools phrase app
-func (c *Conn) Phrase(ctx context.Context, uuid, macro string, times int, wait bool) error {
+func (c *Conn) Phrase(ctx context.Context, uuid, macro string, times int, wait bool) (*RawResponse, error) {
 	return c.audioCommand(ctx, "phrase", uuid, macro, times, wait)
 }
 
 // PhraseWithArg - Executes the mod_dptools phrase app with arguments
-func (c *Conn) PhraseWithArg(ctx context.Context, uuid, macro string, argument interface{}, times int, wait bool) error {
+func (c *Conn) PhraseWithArg(ctx context.Context, uuid, macro string, argument interface{}, times int, wait bool) (*RawResponse, error) {
 	return c.audioCommand(ctx, "phrase", uuid, fmt.Sprintf("%s,%v", macro, argument), times, wait)
 }
 
 // Playback - Executes the mod_dptools playback app
-func (c *Conn) Playback(ctx context.Context, uuid, audioArgs string, times int, wait bool) error {
+func (c *Conn) Playback(ctx context.Context, uuid, audioArgs string, times int, wait bool) (*RawResponse, error) {
 	return c.audioCommand(ctx, "playback", uuid, audioArgs, times, wait)
 }
 
 // Say - Executes the mod_dptools say app
-func (c *Conn) Say(ctx context.Context, uuid, audioArgs string, times int, wait bool) error {
+func (c *Conn) Say(ctx context.Context, uuid, audioArgs string, times int, wait bool) (*RawResponse, error) {
 	return c.audioCommand(ctx, "say", uuid, audioArgs, times, wait)
 }
 
 // Speak - Executes the mod_dptools speak app
-func (c *Conn) Speak(ctx context.Context, uuid, audioArgs string, times int, wait bool) error {
+func (c *Conn) Speak(ctx context.Context, uuid, audioArgs string, times int, wait bool) (*RawResponse, error) {
 	return c.audioCommand(ctx, "speak", uuid, audioArgs, times, wait)
 }
 
@@ -166,7 +166,7 @@ func (c *Conn) WaitForDTMF(ctx context.Context, uuid string) (byte, error) {
 }
 
 // Helper for mod_dptools apps since they are very similar in invocation
-func (c *Conn) audioCommand(ctx context.Context, command, uuid, audioArgs string, times int, wait bool) error {
+func (c *Conn) audioCommand(ctx context.Context, command, uuid, audioArgs string, times int, wait bool) (*RawResponse, error) {
 	response, err := c.SendCommand(ctx, &call.Execute{
 		UUID:    uuid,
 		AppName: command,
@@ -175,10 +175,10 @@ func (c *Conn) audioCommand(ctx context.Context, command, uuid, audioArgs string
 		Sync:    wait,
 	})
 	if err != nil {
-		return err
+		return response, err
 	}
 	if !response.IsOk() {
-		return errors.New(command + " response is not okay")
+		return response, errors.New(command + " response is not okay")
 	}
-	return nil
+	return response, nil
 }

--- a/helper.go
+++ b/helper.go
@@ -149,8 +149,10 @@ func (c *Conn) WaitForDTMF(ctx context.Context, uuid string) (byte, error) {
 			done <- 0
 		}
 	})
-	defer c.RemoveEventListener(uuid, listenerID)
-	defer close(done)
+	defer func() {
+		c.RemoveEventListener(uuid, listenerID)
+		close(done)
+	}()
 
 	select {
 	case digit := <-done:


### PR DESCRIPTION
# Context

There was a rare race condition in WaitForDTMF. Also improve the audio helpers to return the response for some advanced use cases.

# Overview
- Fixes the defer call to ensure the listener gets removed before closing the channel since defer gets called LIFO
- Return the *RawRespone from all of the audio commands