### PR TITLE
Add support for mod_dptools push.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ eslgo was written from the ground up in idiomatic Go for use in our production p
 go get github.com/percipia/eslgo
 ```
 ```
-github.com/percipia/eslgo v1.2.0
+github.com/percipia/eslgo v1.3.1
 ```
 
 ## Overview

--- a/command/call/execute.go
+++ b/command/call/execute.go
@@ -27,9 +27,8 @@ type Execute struct {
 	SyncPri bool
 }
 
-// Helper to call Execute with Set or Export since it is commonly used
+// Helper to call Execute with Set since it is commonly used
 type Set struct {
-	Export  bool
 	UUID    string
 	Key     string
 	Value   string
@@ -37,18 +36,33 @@ type Set struct {
 	SyncPri bool
 }
 
-func (s Set) BuildMessage() string {
+// Helper to call Execute with Export since it is commonly used
+type Export Set
+
+// Helper to call Execute with Push since it is commonly used
+type Push Set
+
+func (s Set) buildMessage(app string) string {
 	e := Execute{
 		UUID:    s.UUID,
-		AppName: "set",
+		AppName: app,
 		AppArgs: fmt.Sprintf("%s=%s", s.Key, s.Value),
 		Sync:    s.Sync,
 		SyncPri: s.SyncPri,
 	}
-	if s.Export {
-		e.AppName = "export"
-	}
 	return e.BuildMessage()
+}
+
+func (s Set) BuildMessage() string {
+	return s.buildMessage("set")
+}
+
+func (e Export) BuildMessage() string {
+	return Set(e).buildMessage("export")
+}
+
+func (p Push) BuildMessage() string {
+	return Set(p).buildMessage("push")
 }
 
 func (e *Execute) BuildMessage() string {

--- a/command/call/execute_test.go
+++ b/command/call/execute_test.go
@@ -27,6 +27,16 @@ Call-Command: execute
 Execute-App-Arg: hello=world
 Execute-App-Name: set
 Loops: 1`, "\n", "\r\n")
+	TestExportMessage = strings.ReplaceAll(`sendmsg none
+Call-Command: execute
+Execute-App-Arg: hello=world
+Execute-App-Name: export
+Loops: 1`, "\n", "\r\n")
+	TestPushMessage = strings.ReplaceAll(`sendmsg none
+Call-Command: execute
+Execute-App-Arg: hello=world
+Execute-App-Name: push
+Loops: 1`, "\n", "\r\n")
 )
 
 func TestExecute_BuildMessage(t *testing.T) {
@@ -45,4 +55,22 @@ func TestSet_BuildMessage(t *testing.T) {
 		Value: "world",
 	}
 	assert.Equal(t, TestSetMessage, set.BuildMessage())
+}
+
+func TestExport_BuildMessage(t *testing.T) {
+	export := Export{
+		UUID:  "none",
+		Key:   "hello",
+		Value: "world",
+	}
+	assert.Equal(t, TestExportMessage, export.BuildMessage())
+}
+
+func TestPush_BuildMessage(t *testing.T) {
+	push := Push{
+		UUID:  "none",
+		Key:   "hello",
+		Value: "world",
+	}
+	assert.Equal(t, TestPushMessage, push.BuildMessage())
 }


### PR DESCRIPTION
# Context
This isn't documented on the Wiki but according to https://github.com/signalwire/freeswitch/commit/4eee5aee8c94910f65f47ade4e873aa62e7117eb it can be used to set multiple values for a variable. This is useful for multipart SIP messages for example.

# Overview
- Remove the export member of `Set`
- Type alias `Set` with `Export` and `Push`
- Create a private method of `Set` that takes in the app name and builds the message with that app name
- Create their `BuildMessage` methods that cast themselves back to `Set` and call the private build method
- Add unit tests for Export and Push