### PR TITLE
Send AppArgs for Set/Export/Push via the body of the SendMessage execute command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ eslgo was written from the ground up in idiomatic Go for use in our production p
 go get github.com/percipia/eslgo
 ```
 ```
-github.com/percipia/eslgo v1.3.1
+github.com/percipia/eslgo v1.3.2
 ```
 
 ## Overview

--- a/command/call/execute.go
+++ b/command/call/execute.go
@@ -18,13 +18,14 @@ import (
 )
 
 type Execute struct {
-	UUID    string
-	AppName string
-	AppArgs string
-	AppUUID string
-	Loops   int
-	Sync    bool
-	SyncPri bool
+	UUID      string
+	AppName   string
+	AppArgs   string
+	AppUUID   string
+	Loops     int
+	Sync      bool
+	SyncPri   bool
+	ForceBody bool
 }
 
 // Helper to call Execute with Set since it is commonly used
@@ -44,11 +45,12 @@ type Push Set
 
 func (s Set) buildMessage(app string) string {
 	e := Execute{
-		UUID:    s.UUID,
-		AppName: app,
-		AppArgs: fmt.Sprintf("%s=%s", s.Key, s.Value),
-		Sync:    s.Sync,
-		SyncPri: s.SyncPri,
+		UUID:      s.UUID,
+		AppName:   app,
+		AppArgs:   fmt.Sprintf("%s=%s", s.Key, s.Value),
+		Sync:      s.Sync,
+		SyncPri:   s.SyncPri,
+		ForceBody: true,
 	}
 	return e.BuildMessage()
 }
@@ -84,7 +86,7 @@ func (e *Execute) BuildMessage() string {
 	}
 
 	// According to documentation that is the max header length
-	if len(e.AppArgs) > 2048 {
+	if len(e.AppArgs) > 2048 || e.ForceBody {
 		sendMsg.Headers.Set("content-type", "text/plain")
 		sendMsg.Headers.Set("content-length", strconv.Itoa(len(e.AppArgs)))
 		sendMsg.Body = e.AppArgs

--- a/command/call/execute_test.go
+++ b/command/call/execute_test.go
@@ -24,19 +24,28 @@ Execute-App-Name: playback
 Loops: 1`, "\n", "\r\n")
 	TestSetMessage = strings.ReplaceAll(`sendmsg none
 Call-Command: execute
-Execute-App-Arg: hello=world
+Content-Length: 11
+Content-Type: text/plain
 Execute-App-Name: set
-Loops: 1`, "\n", "\r\n")
+Loops: 1
+
+hello=world`, "\n", "\r\n")
 	TestExportMessage = strings.ReplaceAll(`sendmsg none
 Call-Command: execute
-Execute-App-Arg: hello=world
+Content-Length: 11
+Content-Type: text/plain
 Execute-App-Name: export
-Loops: 1`, "\n", "\r\n")
+Loops: 1
+
+hello=world`, "\n", "\r\n")
 	TestPushMessage = strings.ReplaceAll(`sendmsg none
 Call-Command: execute
-Execute-App-Arg: hello=world
+Content-Length: 11
+Content-Type: text/plain
 Execute-App-Name: push
-Loops: 1`, "\n", "\r\n")
+Loops: 1
+
+hello=world`, "\n", "\r\n")
 )
 
 func TestExecute_BuildMessage(t *testing.T) {


### PR DESCRIPTION
# Context
When attempting to set special characters(`\r` or `\n` in particular) in variables via the `execute-app-arg` they can be stripped out by the ESL header parser. This can cause issues when trying to format `sip_multipart` variables that include multipart headers.

# Overview
- Add a boolean parameter `ForceBody` to the Execute command. This will force the app arguments into the body even if it's less than 2048 characters.
- Make all Set/Export/Push commands force their arguments to the body to ensure nothing gets lost.
- Update the unit tests to match that the arguments are now in the body of the message.