### PR TITLE
Fix connections not properly stopping for invalid inbound authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ eslgo was written from the ground up in idiomatic Go for use in our production p
 go get github.com/percipia/eslgo
 ```
 ```
-github.com/percipia/eslgo v1.3.2
+github.com/percipia/eslgo v1.3.3
 ```
 
 ## Overview
@@ -90,6 +90,6 @@ func main() {
 
 	// Close the connection after sleeping for a bit
 	time.Sleep(60 * time.Second)
-	conn.Close()
+	conn.ExitAndClose()
 }
 ```

--- a/example/events/events.go
+++ b/example/events/events.go
@@ -35,7 +35,7 @@ func main() {
 	})
 
 	// Ensure all events are enabled
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	_ = conn.EnableEvents(ctx)
 	cancel()
 
@@ -48,7 +48,7 @@ func main() {
 		}
 	}
 
-	// Remove the listener and close the connection
+	// Remove the listener and close the connection gracefully
 	conn.RemoveEventListener(eslgo.EventListenAll, listenerID)
-	conn.Close()
+	conn.ExitAndClose()
 }

--- a/example/inbound/inbound.go
+++ b/example/inbound/inbound.go
@@ -37,5 +37,5 @@ func main() {
 
 	// Close the connection after sleeping for a bit
 	time.Sleep(60 * time.Second)
-	conn.Close()
+	conn.ExitAndClose()
 }

--- a/outbound.go
+++ b/outbound.go
@@ -54,7 +54,7 @@ func (c *Conn) outboundHandle(handler OutboundHandler) {
 	if err != nil {
 		log.Printf("Error connecting to %s error %s", c.conn.RemoteAddr().String(), err.Error())
 		// Try closing cleanly first
-		c.Close()
+		c.Close() // Not ExitAndClose since this error connection is most likely from communication failure
 		return
 	}
 	handler(c.runningContext, c, response)
@@ -67,7 +67,7 @@ func (c *Conn) outboundHandle(handler OutboundHandler) {
 	ctx, cancel = context.WithTimeout(c.runningContext, 5*time.Second)
 	_, _ = c.SendCommand(ctx, command.Exit{})
 	cancel()
-	c.Close()
+	c.ExitAndClose()
 }
 
 func (c *Conn) dummyLoop() {


### PR DESCRIPTION
# Context
We were not properly reporting the auth error, or closing the connection for an invalid password in the inbound ESL connection. This MR Also ensures we send the exit command where it logically makes sense to ensure that we try our best to inform FreeSWITCH of us stopping the connection.

Resolves #5 

# Overview
- Buffer the authentication request channel to ensure we do not miss the request at all
  - Never has been an issue but it was technically racey before this change.
- Add in an exported `ExitAndClose` helper function on `eslgo.Conn` that does exactly what it sounds like. It will send the exit command to FreeSWITCH before closing the network connections.
  - Some `Close`s were switched to `ExitAndClose`s to inform FreeSWITCH gracefully of the closing.
- Fix inbound `Dial` to return the auth error when it fails and to `ExitAndClose` the connection 
- Also close the inbound connection if subsequent authentication checks fail.
- Add a checks to ensure the onDisconnect function pointer isn't nil
- Fix the locking in the receive message loop in `Conn`