### PR TITLE
Configurable Option Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ eslgo was written from the ground up in idiomatic Go for use in our production p
 go get github.com/percipia/eslgo
 ```
 ```
-github.com/percipia/eslgo v1.3.3
+github.com/percipia/eslgo v1.4.0
 ```
 
 ## Overview

--- a/command/command.go
+++ b/command/command.go
@@ -10,6 +10,7 @@
  */
 package command
 
+// Command - A basic interface for FreeSWITCH ESL commands. Implement this if you want to send your own raw data to FreeSIWTCH over the ESL connection. Do not add the eslgo.EndOfMessage(\r\n\r\n) marker, eslgo does that for you.
 type Command interface {
 	BuildMessage() string
 }

--- a/connection.go
+++ b/connection.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"github.com/google/uuid"
 	"github.com/percipia/eslgo/command"
-	"log"
 	"net"
 	"net/textproto"
 	"sync"
@@ -35,14 +34,25 @@ type Conn struct {
 	eventListenerLock sync.RWMutex
 	eventListeners    map[string]map[string]EventListener
 	outbound          bool
+	logger            Logger
 	closeOnce         sync.Once
+}
+
+// Options - Generic options for an ESL connection, either inbound or outbound
+type Options struct {
+	Logger Logger // This specifies the logger to be used for any library internal messages. Can be set to nil to suppress everything.
 }
 
 const EndOfMessage = "\r\n\r\n"
 
-func newConnection(c net.Conn, outbound bool) *Conn {
+func newConnection(c net.Conn, outbound bool, opts Options) *Conn {
 	reader := bufio.NewReader(c)
 	header := textproto.NewReader(reader)
+
+	// If logger is nil, do not actually output anything
+	if opts.Logger == nil {
+		opts.Logger = NilLogger{}
+	}
 
 	runningContext, stop := context.WithCancel(context.Background())
 
@@ -63,12 +73,14 @@ func newConnection(c net.Conn, outbound bool) *Conn {
 		stopFunc:       stop,
 		eventListeners: make(map[string]map[string]EventListener),
 		outbound:       outbound,
+		logger:         opts.Logger,
 	}
 	go instance.receiveLoop()
 	go instance.eventLoop()
 	return instance
 }
 
+// RegisterEventListener - Registers a new event listener for the specified channel UUID(or EventListenAll). Returns the registered listener ID used to remove it.
 func (c *Conn) RegisterEventListener(channelUUID string, listener EventListener) string {
 	c.eventListenerLock.Lock()
 	defer c.eventListenerLock.Unlock()
@@ -82,6 +94,7 @@ func (c *Conn) RegisterEventListener(channelUUID string, listener EventListener)
 	return id
 }
 
+// RemoveEventListener - Removes the listener for the specified channel UUID with the listener ID returned from RegisterEventListener
 func (c *Conn) RemoveEventListener(channelUUID string, id string) {
 	c.eventListenerLock.Lock()
 	defer c.eventListenerLock.Unlock()
@@ -91,6 +104,7 @@ func (c *Conn) RemoveEventListener(channelUUID string, id string) {
 	}
 }
 
+// SendCommand - Sends the specified ESL command to FreeSWITCH with the provided context. Returns the response data and any errors encountered.
 func (c *Conn) SendCommand(ctx context.Context, command command.Command) (*RawResponse, error) {
 	c.writeLock.Lock()
 	defer c.writeLock.Unlock()
@@ -124,6 +138,7 @@ func (c *Conn) SendCommand(ctx context.Context, command command.Command) (*RawRe
 	}
 }
 
+// ExitAndClose - Attempt to gracefully send FreeSWITCH "exit" over the ESL connection before closing our connection and stopping. Protected by a sync.Once
 func (c *Conn) ExitAndClose() {
 	c.closeOnce.Do(func() {
 		// Attempt a graceful closing of the connection with FreeSWITCH
@@ -134,6 +149,7 @@ func (c *Conn) ExitAndClose() {
 	})
 }
 
+// Close - Close our connection to FreeSWITCH without sending "exit". Protected by a sync.Once
 func (c *Conn) Close() {
 	c.closeOnce.Do(c.close)
 }
@@ -228,7 +244,7 @@ func (c *Conn) eventLoop() {
 		c.responseChanMutex.RUnlock()
 
 		if err != nil {
-			log.Printf("Error parsing event\n%s\n", err.Error())
+			c.logger.Warn("Error parsing event\n%s\n", err.Error())
 			continue
 		}
 
@@ -240,7 +256,7 @@ func (c *Conn) receiveLoop() {
 	for c.runningContext.Err() == nil {
 		err := c.doMessage()
 		if err != nil {
-			log.Println("Error receiving message", err)
+			c.logger.Warn("Error receiving message: %s\n", err.Error())
 			break
 		}
 	}
@@ -273,7 +289,7 @@ func (c *Conn) doMessage() error {
 			return c.runningContext.Err()
 		case <-ctx.Done():
 			// Do not return an error since this is not fatal but log since it could be a indication of problems
-			log.Printf("No one to handle response\nIs the connection overloaded or stopping?\n%v\n\n", response)
+			c.logger.Warn("No one to handle response\nIs the connection overloaded or stopping?\n%v\n\n", response)
 		}
 	} else {
 		return errors.New("no response channel for Content-Type: " + response.GetHeader("Content-Type"))

--- a/connection.go
+++ b/connection.go
@@ -46,6 +46,13 @@ type Options struct {
 	ExitTimeout time.Duration   // How long should we wait for FreeSWITCH to respond to our "exit" command. 5 seconds is a sane default.
 }
 
+// DefaultOptions - The default options used for creating the connection
+var DefaultOptions = Options{
+	Context:     context.Background(),
+	Logger:      NormalLogger{},
+	ExitTimeout: 5 * time.Second,
+}
+
 const EndOfMessage = "\r\n\r\n"
 
 func newConnection(c net.Conn, outbound bool, opts Options) *Conn {

--- a/connection_test.go
+++ b/connection_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestConn_SendCommand(t *testing.T) {
 	server, client := net.Pipe()
-	connection := newConnection(client, false)
+	connection := newConnection(client, false, DefaultOptions)
 	defer connection.Close()
 	defer server.Close()
 	defer client.Close()

--- a/event_test.go
+++ b/event_test.go
@@ -21,7 +21,7 @@ const TestEventToSend = "Content-Length: 483\r\nContent-Type: text/event-plain\r
 
 func TestEvent_readPlainEvent(t *testing.T) {
 	server, client := net.Pipe()
-	connection := newConnection(client, false)
+	connection := newConnection(client, false, DefaultOptions)
 	defer connection.Close()
 	defer server.Close()
 	defer client.Close()

--- a/inbound.go
+++ b/inbound.go
@@ -14,34 +14,54 @@ import (
 	"context"
 	"fmt"
 	"github.com/percipia/eslgo/command"
-	"log"
 	"net"
 )
 
+// InboundOptions - Used to dial a new inbound ESL connection to FreeSWITCH
+type InboundOptions struct {
+	Options             // Generic common options to both Inbound and Outbound Conn
+	Address      string // The address to pass into dial, normally 127.0.0.1:8084
+	Network      string // The network type to use, should always be tcp, tcp4, tcp6.
+	Password     string // The password used to authenticate with FreeSWITCH. Usually ClueCon
+	OnDisconnect func() // An optional function to be called with the inbound connection gets disconnected
+}
+
+// Dial - Connects to FreeSWITCH ESL at the provided address and authenticates with the provided password. onDisconnect is called when the connection is closed either by us, FreeSWITCH, or network error
 func Dial(address, password string, onDisconnect func()) (*Conn, error) {
-	c, err := net.Dial("tcp", address)
+	return InboundOptions{
+		Options:      Options{Logger: NormalLogger{}},
+		Address:      address,
+		Network:      "tcp",
+		Password:     password,
+		OnDisconnect: onDisconnect,
+	}.Dial()
+}
+
+// Dial - Connections to FreeSWITCH ESL with the provided options. Returns the connection and any errors encountered
+func (opts InboundOptions) Dial() (*Conn, error) {
+	c, err := net.Dial(opts.Network, opts.Address)
 	if err != nil {
 		return nil, err
 	}
-	connection := newConnection(c, false)
+	connection := newConnection(c, false, opts.Options)
 
 	// First auth
 	<-connection.responseChannels[TypeAuthRequest]
-	err = connection.doAuth(connection.runningContext, command.Auth{Password: password})
+	err = connection.doAuth(connection.runningContext, command.Auth{Password: opts.Password})
 	if err != nil {
 		// Try to gracefully disconnect, we have the wrong password.
 		connection.ExitAndClose()
-		if onDisconnect != nil {
-			go onDisconnect()
+		if opts.OnDisconnect != nil {
+			go opts.OnDisconnect()
 		}
 		return nil, err
 	} else {
-		log.Printf("Sucessfully authenticated %s\n", connection.conn.RemoteAddr())
+		connection.logger.Info("Successfully authenticated %s\n", connection.conn.RemoteAddr())
 	}
 
 	// Inbound only handlers
-	go connection.authLoop(command.Auth{Password: password})
-	go connection.disconnectLoop(onDisconnect)
+	go connection.authLoop(command.Auth{Password: opts.Password})
+	go connection.disconnectLoop(opts.OnDisconnect)
 
 	return connection, nil
 }
@@ -65,12 +85,12 @@ func (c *Conn) authLoop(auth command.Auth) {
 		case <-c.responseChannels[TypeAuthRequest]:
 			err := c.doAuth(c.runningContext, auth)
 			if err != nil {
-				log.Printf("Failed to auth %e\n", err)
+				c.logger.Warn("Failed to auth %e\n", err)
 				// Close the connection, we have the wrong password
 				c.ExitAndClose()
 				return
 			} else {
-				log.Printf("Sucessfully authenticated %s\n", c.conn.RemoteAddr())
+				c.logger.Info("Successfully authenticated %s\n", c.conn.RemoteAddr())
 			}
 		case <-c.runningContext.Done():
 			return

--- a/inbound.go
+++ b/inbound.go
@@ -29,11 +29,7 @@ type InboundOptions struct {
 
 // DefaultOutboundOptions - The default options used for creating the inbound connection
 var DefaultInboundOptions = InboundOptions{
-	Options: Options{
-		Context:     context.Background(),
-		Logger:      NormalLogger{},
-		ExitTimeout: 5 * time.Second,
-	},
+	Options:     DefaultOptions,
 	Network:     "tcp",
 	Password:    "ClueCon",
 	AuthTimeout: 5 * time.Second,

--- a/logger.go
+++ b/logger.go
@@ -16,19 +16,19 @@ type NormalLogger struct{}
 
 func (l NormalLogger) Debug(format string, args ...interface{}) {
 	log.Print("DEBUG: ")
-	log.Printf(format, args)
+	log.Printf(format, args...)
 }
 func (l NormalLogger) Info(format string, args ...interface{}) {
 	log.Print("INFO: ")
-	log.Printf(format, args)
+	log.Printf(format, args...)
 }
 func (l NormalLogger) Warn(format string, args ...interface{}) {
 	log.Print("WARN: ")
-	log.Printf(format, args)
+	log.Printf(format, args...)
 }
 func (l NormalLogger) Error(format string, args ...interface{}) {
 	log.Print("ERROR: ")
-	log.Printf(format, args)
+	log.Printf(format, args...)
 }
 
 func (l NilLogger) Debug(string, ...interface{}) {}

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,37 @@
+package eslgo
+
+import (
+	"log"
+)
+
+type Logger interface {
+	Debug(format string, args ...interface{})
+	Info(format string, args ...interface{})
+	Warn(format string, args ...interface{})
+	Error(format string, args ...interface{})
+}
+
+type NilLogger struct{}
+type NormalLogger struct{}
+
+func (l NormalLogger) Debug(format string, args ...interface{}) {
+	log.Print("DEBUG: ")
+	log.Printf(format, args)
+}
+func (l NormalLogger) Info(format string, args ...interface{}) {
+	log.Print("INFO: ")
+	log.Printf(format, args)
+}
+func (l NormalLogger) Warn(format string, args ...interface{}) {
+	log.Print("WARN: ")
+	log.Printf(format, args)
+}
+func (l NormalLogger) Error(format string, args ...interface{}) {
+	log.Print("ERROR: ")
+	log.Printf(format, args)
+}
+
+func (l NilLogger) Debug(string, ...interface{}) {}
+func (l NilLogger) Info(string, ...interface{})  {}
+func (l NilLogger) Warn(string, ...interface{})  {}
+func (l NilLogger) Error(string, ...interface{}) {}

--- a/outbound.go
+++ b/outbound.go
@@ -14,45 +14,72 @@ import (
 	"context"
 	"errors"
 	"github.com/percipia/eslgo/command"
-	"log"
 	"net"
 	"time"
 )
 
 type OutboundHandler func(ctx context.Context, conn *Conn, connectResponse *RawResponse)
 
+// OutboundOptions - Used to open a new listener for outbound ESL connections from FreeSWITCH
+type OutboundOptions struct {
+	Options                       // Generic common options to both Inbound and Outbound Conn
+	Address         string        // The address to bind to for listening for inbound FreeSWITCH connections
+	Network         string        // The network type to listen on, should be tcp, tcp4, or tcp6
+	ConnectTimeout  time.Duration // How long should we wait for FreeSWITCH to respond to our "connect" command. 5 seconds is a sane default.
+	ExitTimeout     time.Duration // How long should we wait for FreeSWITCH to respond to our "exit" command. 5 seconds is a sane default.
+	ConnectionDelay time.Duration // How long should we wait after connection to start sending commands. 25ms is the recommended default otherwise we can close the connection before FreeSWITCH finishes starting it on their end. https://github.com/signalwire/freeswitch/pull/636
+}
+
 /*
  * TODO: Review if we should have a rate limiting facility to prevent DoS attacks
  * For our use it should be fine since we only want to listen on localhost
  */
+// ListenAndServe - Open a new listener for outbound ESL connections from FreeSWITCH on the specified address with the provided connection handler
 func ListenAndServe(address string, handler OutboundHandler) error {
-	listener, err := net.Listen("tcp", address)
+	return OutboundOptions{
+		Options:         Options{Logger: NormalLogger{}},
+		Address:         address,
+		Network:         "tcp",
+		ConnectTimeout:  5 * time.Second,
+		ExitTimeout:     5 * time.Second,
+		ConnectionDelay: 25 * time.Millisecond,
+	}.ListenAndServe(handler)
+}
+
+// ListenAndServe - Open a new listener for outbound ESL connections from FreeSWITCH with provided options and handle them with the specified handler
+func (opts OutboundOptions) ListenAndServe(handler OutboundHandler) error {
+	listener, err := net.Listen(opts.Network, opts.Address)
 	if err != nil {
 		return err
 	}
-	log.Printf("Listenting for new ESL connections on %s\n", listener.Addr().String())
+	if opts.Logger != nil {
+		opts.Logger.Info("Listening for new ESL connections on %s\n", listener.Addr().String())
+	}
 	for {
 		c, err := listener.Accept()
 		if err != nil {
 			break
 		}
+		conn := newConnection(c, true, opts.Options)
 
-		log.Printf("New outbound connection from %s\n", c.RemoteAddr().String())
-		conn := newConnection(c, true)
+		conn.logger.Info("New outbound connection from %s\n", c.RemoteAddr().String())
 		go conn.dummyLoop()
 		// Does not call the handler directly to ensure closing cleanly
-		go conn.outboundHandle(handler)
+		go conn.outboundHandle(handler, opts.ConnectionDelay, opts.ConnectTimeout, opts.ExitTimeout)
 	}
-	log.Println("Outbound server shutting down")
+
+	if opts.Logger != nil {
+		opts.Logger.Info("Outbound server shutting down")
+	}
 	return errors.New("connection closed")
 }
 
-func (c *Conn) outboundHandle(handler OutboundHandler) {
-	ctx, cancel := context.WithTimeout(c.runningContext, 5*time.Second)
+func (c *Conn) outboundHandle(handler OutboundHandler, connectionDelay, connectTimeout, exitTimeout time.Duration) {
+	ctx, cancel := context.WithTimeout(c.runningContext, connectTimeout)
 	response, err := c.SendCommand(ctx, command.Connect{})
 	cancel()
 	if err != nil {
-		log.Printf("Error connecting to %s error %s", c.conn.RemoteAddr().String(), err.Error())
+		c.logger.Warn("Error connecting to %s error %s", c.conn.RemoteAddr().String(), err.Error())
 		// Try closing cleanly first
 		c.Close() // Not ExitAndClose since this error connection is most likely from communication failure
 		return
@@ -61,10 +88,9 @@ func (c *Conn) outboundHandle(handler OutboundHandler) {
 	// XXX This is ugly, the issue with short lived async sockets on our end is if they complete too fast we can actually
 	// close the connection before FreeSWITCH is in a state to close the connection on their end. 25ms is an magic value
 	// found by testing to have no failures on my test system. I started at 1 second and reduced as far as I could go.
-	// TODO We should open a bug report on the FreeSWITCH GitHub at some point and remove this when fixed.
 	// TODO This actually may be fixed: https://github.com/signalwire/freeswitch/pull/636
-	time.Sleep(25 * time.Millisecond)
-	ctx, cancel = context.WithTimeout(c.runningContext, 5*time.Second)
+	time.Sleep(connectionDelay)
+	ctx, cancel = context.WithTimeout(c.runningContext, exitTimeout)
 	_, _ = c.SendCommand(ctx, command.Exit{})
 	cancel()
 	c.ExitAndClose()
@@ -73,10 +99,10 @@ func (c *Conn) outboundHandle(handler OutboundHandler) {
 func (c *Conn) dummyLoop() {
 	select {
 	case <-c.responseChannels[TypeDisconnect]:
-		log.Println("Disconnect outbound connection", c.conn.RemoteAddr())
+		c.logger.Info("Disconnect outbound connection", c.conn.RemoteAddr())
 		c.Close()
 	case <-c.responseChannels[TypeAuthRequest]:
-		log.Println("Ignoring auth request on outbound connection", c.conn.RemoteAddr())
+		c.logger.Debug("Ignoring auth request on outbound connection", c.conn.RemoteAddr())
 	case <-c.runningContext.Done():
 		return
 	}

--- a/outbound.go
+++ b/outbound.go
@@ -30,11 +30,7 @@ type OutboundOptions struct {
 
 // DefaultOutboundOptions - The default options used for creating the outbound connection
 var DefaultOutboundOptions = OutboundOptions{
-	Options: Options{
-		Context:     context.Background(),
-		Logger:      NormalLogger{},
-		ExitTimeout: 5 * time.Second,
-	},
+	Options:         DefaultOptions,
 	Network:         "tcp",
 	ConnectTimeout:  5 * time.Second,
 	ConnectionDelay: 25 * time.Millisecond,

--- a/utils.go
+++ b/utils.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 )
 
+// BuildVars - A helper that builds channel variable strings to be included in various commands to FreeSWITCH
 func BuildVars(format string, vars map[string]string) string {
 	// No vars do not format
 	if vars == nil || len(vars) == 0 {


### PR DESCRIPTION
# Context
There were hard-coded defaults and logging functions that worked fine for our internal usage but may need to be changed by others for their use case. This allows better configuration and customization to cover more use cases.

# Overview
- Add Options, InboundOptions. and OutboundOptions to allow configuring all of the options for each specific part of the connection.
- Extract various magic values and default timeout settings into their respective option structs
- Add in a generic logger interface type to allow outside loggers to handle the log messages
- Add in new Dial and ListenAndServe methods that use their option structs and make the old functions call the new ones internally to maintain backwards compatibility.
- Add in default stdout and nil loggers to be used for logging and maintaining existing outputs.