### PR TITLE
Trying to fix race condition when channel is closed and there is an attempt to read channel

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -154,14 +154,14 @@ func (c *Conn) SendCommand(ctx context.Context, cmd command.Command) (*RawRespon
 	c.responseChanMutex.RLock()
 	defer c.responseChanMutex.RUnlock()
 	select {
-	case response := <-c.responseChannels[TypeReply]:
-		if response == nil {
+	case response, ok := <-c.responseChannels[TypeReply]:
+		if !ok || response == nil {
 			// We only get nil here if the channel is closed
 			return nil, errors.New("connection closed")
 		}
 		return response, nil
-	case response := <-c.responseChannels[TypeAPIResponse]:
-		if response == nil {
+	case response, ok := <-c.responseChannels[TypeAPIResponse]:
+		if !ok || response == nil {
 			// We only get nil here if the channel is closed
 			return nil, errors.New("connection closed")
 		}


### PR DESCRIPTION
When a channel is closed, there are times when the event handler trying to access a closed channel, and a race condition happens.

At the moment on my tests it does not happen anymore, but I'm not sure if that fixes the issue, or it is just "lack".

The fix is simple -> adding a channel check (2nd argument), if the `ok` variable is false, the channel is closed.

I hope this fixes issue #36.

