### PR TITLE
Fix: panic: send on closed channel in `receiveLoop` on EOF

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -293,6 +293,7 @@ func (c *Conn) receiveLoop() {
 			if err.Error() == "EOF" {
 				c.logger.Warn("Connection closed, stopping receive loop\n")
 				c.responseChanMutex.RLock()
+				defer c.responseChanMutex.RUnlock()
 				disconnectCh, ok := c.responseChannels[TypeDisconnect]
 				if ok {
 					select {
@@ -306,7 +307,6 @@ func (c *Conn) receiveLoop() {
 					default:
 					}
 				}
-				c.responseChanMutex.RUnlock()
 				return
 			}
 			break

--- a/connection.go
+++ b/connection.go
@@ -290,21 +290,23 @@ func (c *Conn) receiveLoop() {
 		err := c.doMessage()
 		if err != nil {
 			c.logger.Warn("Error receiving message: %s\n", err.Error())
-			// when err.Error() is EOF we should trigger event to responseChannel and exit the loop
-			// because the connection is closed
 			if err.Error() == "EOF" {
-				// send signal to c.responseChannels[TypeDisconnect]
 				c.logger.Warn("Connection closed, stopping receive loop\n")
-				select {
-				case c.responseChannels[TypeDisconnect] <- &RawResponse{
-					Headers: textproto.MIMEHeader{
-						"Content-Type": []string{TypeDisconnect},
-						"Error":        []string{err.Error()},
-					},
-					Body: []byte("connection closed: " + err.Error()),
-				}:
-				default:
+				c.responseChanMutex.RLock()
+				disconnectCh, ok := c.responseChannels[TypeDisconnect]
+				if ok {
+					select {
+					case disconnectCh <- &RawResponse{
+						Headers: textproto.MIMEHeader{
+							"Content-Type": []string{TypeDisconnect},
+							"Error":        []string{err.Error()},
+						},
+						Body: []byte("connection closed: " + err.Error()),
+					}:
+					default:
+					}
 				}
+				c.responseChanMutex.RUnlock()
 				return
 			}
 			break

--- a/connection_test.go
+++ b/connection_test.go
@@ -56,3 +56,25 @@ func TestConn_SendCommand(t *testing.T) {
 	assert.Nil(t, err)
 	wait.Wait()
 }
+
+func TestReceiveLoop_NoRaceOnEOF(t *testing.T) {
+	server, client := net.Pipe()
+	connection := newConnection(client, false, DefaultOptions)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(20 * time.Millisecond)
+		server.Close()
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(30 * time.Millisecond)
+		connection.Close()
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
Fixes #46

## Problem

When the remote FreeSWITCH server closes the TCP connection (EOF), `receiveLoop` panics with `send on closed channel` because it attempts to send to the `TypeDisconnect` response channel that has already been closed by a concurrent `close()` call.

```
panic: send on closed channel

goroutine 3110 [running]:
github.com/percipia/eslgo.(*Conn).receiveLoop(0xc0006803c0)
        .../vendor/github.com/percipia/eslgo/connection.go:299 +0x345
```

### Race sequence

1. FreeSWITCH drops the TCP connection — `receiveLoop` receives EOF from `doMessage()`
2. Simultaneously, a caller invokes `ExitAndClose()` — `close()` acquires the write lock, closes and deletes all channels including `TypeDisconnect`
3. `receiveLoop` reads `c.responseChannels[TypeDisconnect]` without holding the mutex — gets the now-closed channel
4. `select` sends on the closed channel — **panic**

## Fix

Guard the EOF disconnect send in `receiveLoop` with `responseChanMutex.RLock()`/`RUnlock()`, and check that the channel still exists in the map before sending. This mirrors the same mutex pattern already used by `doMessage()` when writing to response channels.

```go
c.responseChanMutex.RLock()
disconnectCh, ok := c.responseChannels[TypeDisconnect]
if ok {
    select {
    case disconnectCh <- &RawResponse{...}:
    default:
    }
}
c.responseChanMutex.RUnlock()
```

## Test

Added `TestReceiveLoop_NoRaceOnEOF` which simulates a server-side close (EOF) racing with a client-side `Close()`. Passes cleanly under `go test -race -count=5`.

## Checklist

- [x] All existing tests pass
- [x] Race detector clean (`go test -race -count=5 ./...`)
- [x] Minimal change — only touches the unprotected EOF path
