### PR TITLE
Fix/inbound dial auth timeout

### DIFF
--- a/inbound.go
+++ b/inbound.go
@@ -50,12 +50,35 @@ func (opts InboundOptions) Dial(address string) (*Conn, error) {
 		return nil, err
 	}
 	connection := newConnection(c, false, opts.Options)
+	notifyPreAuthDisconnect := func() {
+		connection.Close()
+		if opts.OnDisconnect != nil {
+			go opts.OnDisconnect()
+		}
+	}
 
 	// First auth
-	<-connection.responseChannels[TypeAuthRequest]
 	authCtx, cancel := context.WithTimeout(connection.runningContext, opts.AuthTimeout)
+	defer cancel()
+
+	select {
+	case _, ok := <-connection.responseChannels[TypeAuthRequest]:
+		if !ok {
+			notifyPreAuthDisconnect()
+			return nil, fmt.Errorf("connection closed before auth request")
+		}
+	case response, ok := <-connection.responseChannels[TypeDisconnect]:
+		notifyPreAuthDisconnect()
+		if ok && response != nil {
+			return nil, fmt.Errorf("connection disconnected before auth request: %s", response.GetHeader("Error"))
+		}
+		return nil, fmt.Errorf("connection disconnected before auth request")
+	case <-authCtx.Done():
+		notifyPreAuthDisconnect()
+		return nil, authCtx.Err()
+	}
+
 	err = connection.doAuth(authCtx, command.Auth{Password: opts.Password})
-	cancel()
 	if err != nil {
 		// Try to gracefully disconnect, we have the wrong password.
 		connection.ExitAndClose()

--- a/inbound_test.go
+++ b/inbound_test.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2020 Percipia
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Contributor(s):
+ * Glenn O. Larsen <glenn.larsen@gmail.com>
+ */
+package eslgo
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInboundDial_ReturnsErrorWhenConnectionClosesBeforeAuthRequest(t *testing.T) {
+	listener := listenTCP(t)
+	defer listener.Close()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		conn.Close()
+	}()
+
+	opts := DefaultInboundOptions
+	opts.AuthTimeout = 100 * time.Millisecond
+	opts.Logger = NilLogger{}
+	disconnected := make(chan struct{})
+	opts.OnDisconnect = func() {
+		close(disconnected)
+	}
+
+	started := time.Now()
+	conn, err := opts.Dial(listener.Addr().String())
+
+	assert.Nil(t, conn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "before auth request")
+	assert.Less(t, time.Since(started), time.Second)
+	assertOnDisconnect(t, disconnected)
+}
+
+func TestInboundDial_ReturnsErrorWhenAuthRequestTimesOut(t *testing.T) {
+	listener := listenTCP(t)
+	defer listener.Close()
+
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		<-done
+	}()
+
+	opts := DefaultInboundOptions
+	opts.AuthTimeout = 100 * time.Millisecond
+	opts.Logger = NilLogger{}
+	disconnected := make(chan struct{})
+	opts.OnDisconnect = func() {
+		close(disconnected)
+	}
+
+	started := time.Now()
+	conn, err := opts.Dial(listener.Addr().String())
+
+	assert.Nil(t, conn)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded))
+	assert.Less(t, time.Since(started), time.Second)
+	assertOnDisconnect(t, disconnected)
+}
+
+func assertOnDisconnect(t *testing.T, disconnected <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-disconnected:
+	case <-time.After(time.Second):
+		t.Fatal("expected OnDisconnect to be called")
+	}
+}
+
+func listenTCP(t *testing.T) net.Listener {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	return listener
+}


### PR DESCRIPTION
Fixes #48 

## Summary

`InboundOptions.Dial` can block forever when the TCP connection succeeds but the remote FreeSWITCH server closes the connection before sending the initial ESL `auth/request`.

This can happen during FreeSWITCH restart or startup, where the event socket port may briefly accept connections before ESL auth is ready.

## Current Behavior

`Dial` creates the connection and then waits unconditionally for `TypeAuthRequest`:

```go
<-connection.responseChannels[TypeAuthRequest]
```

If the server closes the socket before sending `auth/request`, `receiveLoop` logs EOF, but `Dial` remains blocked waiting for the auth request forever.

## Expected Behavior

`Dial` should return an error when:

- the connection closes before `auth/request`
- a disconnect is received before `auth/request`
- `AuthTimeout` expires while waiting for `auth/request`

`AuthTimeout` should cover waiting for the initial auth request, not only sending the auth response.

## Why This Matters

Applications using `Dial` for reconnect loops can become permanently stuck after a FreeSWITCH restart. Since `Dial` never returns, the application cannot retry, back off, or exit for orchestration systems like Kubernetes to restart it.

## Reproduction

1. Start a TCP listener that accepts a connection.
2. Close the accepted connection immediately without sending `Content-Type: auth/request`.
3. Call `InboundOptions.Dial`.
4. `Dial` blocks forever instead of returning an error.

A similar real-world reproduction is restarting FreeSWITCH while an application tries to reconnect to the ESL port.

## Proposed Fix

Replace the blocking auth request receive with a timeout-aware `select`.

The `select` should wait for:

- `TypeAuthRequest`: continue normal auth
- `TypeDisconnect`: close and return an error
- `AuthTimeout`: close and return timeout error
- connection context cancellation: close and return context error

## Test Coverage

Add regression tests for:

- remote closes before sending `auth/request`
- remote accepts TCP but stays silent until `AuthTimeout`

Both cases should return an error quickly instead of blocking forever.
