### PR TITLE
Fix panic: send on closed channel in WaitForDTMF

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -99,10 +99,11 @@ func (c *Conn) WaitForDTMF(ctx context.Context, uuid string) (byte, error) {
 			time.Sleep(10 * time.Millisecond)
 		}
 	})
-	defer func() {
-		c.RemoveEventListener(uuid, listenerID)
-		close(done)
-	}()
+	// Do not close(done) here: a listener goroutine dispatched by
+	// callEventListener may still be running after RemoveEventListener
+	// returns and would panic sending on a closed channel. The buffered
+	// channel is collected once it is no longer referenced.
+	defer c.RemoveEventListener(uuid, listenerID)
 
 	select {
 	case digit := <-done:

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020 Percipia
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Contributor(s):
+ * Andrew Querol <aquerol@percipia.com>
+ */
+package eslgo
+
+import (
+	"context"
+	"net"
+	"net/textproto"
+	"sync"
+	"testing"
+)
+
+// TestWaitForDTMF_NoPanicOnLateEvent reproduces the "send on closed channel"
+// panic from WaitForDTMF: a DTMF listener goroutine is dispatched by
+// callEventListener and may still be running after WaitForDTMF has returned
+// (on ctx cancellation) and closed its done channel.
+func TestWaitForDTMF_NoPanicOnLateEvent(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	conn := newConnection(client, false, DefaultOptions)
+	defer conn.Close()
+
+	const uuid = "test-uuid"
+
+	dtmfEvent := func() *Event {
+		headers := make(textproto.MIMEHeader)
+		headers.Set("Event-Name", "DTMF")
+		headers.Set("Unique-Id", uuid)
+		headers.Set("DTMF-Digit", "1")
+		return &Event{Headers: headers}
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Fire DTMF events concurrently so a listener goroutine is
+			// in-flight when WaitForDTMF returns and closes its channel.
+			for j := 0; j < 5; j++ {
+				conn.callEventListener(dtmfEvent())
+			}
+		}()
+		cancel()
+		_, _ = conn.WaitForDTMF(ctx, uuid)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Fixes #50

## Problem

`WaitForDTMF` panics with `send on closed channel` when a DTMF event arrives while the call is being torn down:

```
panic: send on closed channel
github.com/percipia/eslgo.(*Conn).WaitForDTMF.func1(...)
        helper.go:90
created by github.com/percipia/eslgo.(*Conn).callEventListener
        connection.go:220
```

`callEventListener` dispatches every listener on its own goroutine (`go listener(event)`). When `WaitForDTMF` returns, its deferred cleanup runs `RemoveEventListener` and then `close(done)`. `RemoveEventListener` only deletes the entry from the listener map; it does not wait for listener goroutines that are already in flight. A DTMF listener that was dispatched just before removal (or is parked at the `time.Sleep(10ms)`) then executes `done <- dtmf[0]` after the channel is closed and crashes the process.

## Fix

Drop `close(done)`. The channel is buffered and local to `WaitForDTMF`, and the receive in the `select` does not depend on close semantics, so closing it serves no purpose other than to race with the listener goroutine. Once the function returns and the listener is removed, the channel is no longer referenced and is collected. The listener's sends are already non-blocking (`select { case done <- x: default: }`), so a late event is simply dropped.

## Test

`TestWaitForDTMF_NoPanicOnLateEvent` races concurrent DTMF events against `WaitForDTMF` returning on context cancellation. It panics under `-race` before the change and passes after. This mirrors `TestReceiveLoop_NoRaceOnEOF` added with the `receiveLoop` fix in #47.
